### PR TITLE
add missing key to struct

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -41,6 +41,7 @@ struct TickCounter {
     render_frames: f64,
     avg_render_frames: f64,
     update_ticks: f64,
+    avg_update_ticks: f64,
 }
 
 impl TickCounter {


### PR DESCRIPTION
A line was missing, which was creating compilation errors.